### PR TITLE
improvements to ros_gz_bridge config

### DIFF
--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -57,7 +57,7 @@
 - ros_topic_name: "/mirte_base_controller/odom"
   gz_topic_name: "/odom"
   ros_type_name: "nav_msgs/msg/Odometry"
-  gz_type_name: "gz.msgs.Odometry"
+  gz_type_name: "gz.msgs.OdometryWithCovariance"
   direction: GZ_TO_ROS
   lazy: true
 

--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -3,63 +3,74 @@
   ros_type_name: "rosgraph_msgs/msg/Clock"
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "/scan"
   gz_topic_name: "/scan"
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "/point_cloud"
   gz_topic_name: "/scan/points"
   ros_type_name: "sensor_msgs/msg/PointCloud2"
   gz_type_name: "gz.msgs.PointCloudPacked"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "/imu"
   gz_topic_name: "/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "camera/camera_info"
   gz_topic_name: "camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "camera/image_raw"
   gz_topic_name: "camera/image_raw"
-  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
-  
+  lazy: true
+
 - ros_topic_name: "camera/image_raw/points"
   gz_topic_name: "camera/image_raw/points"
   ros_type_name: "sensor_msgs/msg/PointCloud2"
   gz_type_name: "gz.msgs.PointCloudPacked"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "/cmd_vel"
   gz_topic_name: "/cmd_vel"
   ros_type_name: "geometry_msgs/msg/Twist"
   gz_type_name: "gz.msgs.Twist"
   direction: ROS_TO_GZ
+  lazy: true
 
 - ros_topic_name: "/mirte_base_controller/odom"
   gz_topic_name: "/odom"
   ros_type_name: "nav_msgs/msg/Odometry"
-  gz_type_name: "gz.msgs.OdometryWithCovariance"
+  gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "/joint_states"
   gz_topic_name: "/mirte/joint_states"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
+  lazy: true
 
 - ros_topic_name: "tf"
   gz_topic_name: "/tf"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
-  direction: BIDIRECTIONAL
+  direction: GZ_TO_ROS
+  lazy: true


### PR DESCRIPTION
Add `lazy: true` to each bridged topic. This makes the bridge only publish to ROS when there is a subscriber listening to the topic, which improves performance.
Makes the `/tf` topic unidirectional from GZ to ROS. I don't believe it is necessary to make it bidirectional