### PR TITLE
Add footprint laser filter

### DIFF
--- a/config/laser_filter.yaml
+++ b/config/laser_filter.yaml
@@ -1,0 +1,7 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    filter1:
+      name: footprint_filter
+      type: laser_filters/LaserScanFootprintFilter
+      params:
+        inscribed_radius: 0.165

--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -4,8 +4,8 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/scan"
-  gz_topic_name: "/scan"
+- ros_topic_name: "/scan_unfiltered"
+  gz_topic_name: "/scan_unfiltered"
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS

--- a/launch/mirte_simulation_fortress.launch.py
+++ b/launch/mirte_simulation_fortress.launch.py
@@ -22,7 +22,7 @@ from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
-
+from launch_ros.actions import Node
 
 def generate_launch_description():
   # Use simulation time
@@ -74,10 +74,25 @@ def generate_launch_description():
     launch_arguments={'use_sim_time': use_sim_time}.items()
   )
 
+  mirte_laser_filters = Node(
+    package='laser_filters',
+    executable='scan_to_scan_filter_chain',
+    remappings=[
+      ('/scan', '/scan_unfiltered'),
+      ('/scan_filtered', '/scan'),
+    ],
+    parameters=[
+      PathJoinSubstitution([
+        get_package_share_directory('mirte_gazebo'),
+        'config', 'laser_filter.yaml',
+      ])],
+  )
+
   return LaunchDescription([
     headless_arg,
     use_sim_time_arg,
     world_arg,
     gz_sim,
     spawn_mirte_master,
+    mirte_laser_filters,
   ])

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>gazebo_ros2_control</depend>
   <depend>ign_ros2_control</depend>
   <depend>ros_gz</depend>
+  <depend>laser_filters</depend>
   <depend>ros_ign_gazebo</depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>


### PR DESCRIPTION
Filter `/scan_unfiltered` laser scans to remove points inside the robot's "footprint" (there is no footprint param for the filter, so I used the equivalent inscribed radius of 0.165). Filtered data is published into the `/scan` topic.
Related to PR: https://github.com/EGAlberts/mirte-ros-packages/pull/4