### PR TITLE
fix odom msg type in gz bridge

### DIFF
--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -49,7 +49,7 @@
 - ros_topic_name: "/mirte_base_controller/odom"
   gz_topic_name: "/odom"
   ros_type_name: "nav_msgs/msg/Odometry"
-  gz_type_name: "gz.msgs.OdometryWithCovariance"
+  gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "/joint_states"


### PR DESCRIPTION
Change the Odometry message type from `OdometryWithCovariance` to `Odometry`

Related to: https://github.com/EGAlberts/mirte-ros-packages/pull/6